### PR TITLE
fix: add gcTime and staleTime to getFetchOptions

### DIFF
--- a/src/createBaseQuery.ts
+++ b/src/createBaseQuery.ts
@@ -63,6 +63,8 @@ export const createBaseQuery = (
       getPreviousPageParam: defaultOptions.getPreviousPageParam,
       getNextPageParam: defaultOptions.getNextPageParam,
       initialPageParam: defaultOptions.initialPageParam,
+      staleTime: defaultOptions.staleTime,
+      gcTime: defaultOptions.gcTime,
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,11 +125,13 @@ export type ExposeMethods<TFnData, TVariables, TError, TPageParam = never> = {
     >,
     // @ts-ignore
     [TPageParam] extends [never]
-      ? 'queryKey' | 'queryFn' | 'queryKeyHashFn'
+      ? 'queryKey' | 'queryFn' | 'queryKeyHashFn' | 'gcTime' | 'staleTime'
       :
           | 'queryKey'
           | 'queryFn'
           | 'queryKeyHashFn'
+          | 'gcTime'
+          | 'staleTime'
           | 'getNextPageParam'
           | 'getPreviousPageParam'
           | 'initialPageParam'


### PR DESCRIPTION
Hi,
Adding this change since I encountered a bug connected to it: if you prefetch with `getFetchOptions` it would apply the defaults for those two options, which could lead to race cons and possibly no data in cache when it should be there (my use case was that I was prefetching some data that wouldn't change throughout the app's lifecycle (so, `staleTime`/`gcTime` = `Infinity`) and then using `getQueryData` to get it, noticed some errors about it being undefined)